### PR TITLE
Supply --js prefix for every source file passed to Closure

### DIFF
--- a/make/commands.js
+++ b/make/commands.js
@@ -121,8 +121,7 @@ exports.closureCompiler = function(jar, opts) {
             this.output(val);
     }, this);
     if (js) {
-        args.push("--js");
-        args.push(js);
+        args.push(js.map(function(arg) { return "--js=" + arg; }));
     }
     args = [].concat(args); // flatten one level
     this.java("-jar", jar, args);

--- a/plugins/cindy3d/src/js/Ops3D.js
+++ b/plugins/cindy3d/src/js/Ops3D.js
@@ -306,7 +306,8 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
    * @param {!function(number, number, number, number)} callback  invoked once per mesh face
    */
   function iterMesh(m, n, tcr, tcc, callback) {
-    for (let i = 1, k = 0; i < m; ++i) {
+    let k = 0;
+    for (let i = 1; i < m; ++i) {
       for (let j = 1; j < n; ++j) {
         callback(k, k + 1, k + n + 1, k + n);
         ++k;


### PR DESCRIPTION
Also fixes an issue in Cindy3D that the more recent Closure Compiler is rightly complaining about.
